### PR TITLE
Update to Patch 6.2

### DIFF
--- a/MacroChain.cs
+++ b/MacroChain.cs
@@ -29,7 +29,7 @@ namespace MacroChain {
         private Hook<MacroCallDelegate> macroCallHook;
         
         public MacroChain() {
-            macroCallHook = new Hook<MacroCallDelegate>(new IntPtr(RaptureShellModule.fpExecuteMacro), MacroCallDetour);
+            macroCallHook = Hook<MacroCallDelegate>.FromAddress(new IntPtr(RaptureShellModule.fpExecuteMacro), MacroCallDetour);
             macroCallHook?.Enable();
 
             CommandManager.AddHandler("/nextmacro", new Dalamud.Game.Command.CommandInfo(OnMacroCommandHandler) {

--- a/MacroChain.csproj
+++ b/MacroChain.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup Label="Target">
         <PlatformTarget>x64</PlatformTarget>
-        <TargetFramework>net5.0-windows</TargetFramework>
+        <TargetFramework>net6.0-windows</TargetFramework>
         <LangVersion>8.0</LangVersion>
         <Platforms>x64</Platforms>
         <Configurations>Debug;Release</Configurations>
@@ -18,18 +18,20 @@
         <Version>2.1.0.3</Version>
     </PropertyGroup>
     <PropertyGroup>
+		<AssemblyName>MacroChain</AssemblyName>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-        <AssemblyName>MacroChain</AssemblyName>
-    </PropertyGroup>
+		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+		<DalamudLibPath>$(AppData)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
+	</PropertyGroup>
     <ItemGroup>
         <Reference Include="Dalamud">
             <Private>false</Private>
-            <HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\Dalamud.dll</HintPath>
+            <HintPath>$(DalamudLibPath)\Dalamud.dll</HintPath>
         </Reference>
         <Reference Include="FFXIVClientStructs">
             <Private>false</Private>
-            <HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\FFXIVClientStructs.dll</HintPath>
+            <HintPath>$(DalamudLibPath)\FFXIVClientStructs.dll</HintPath>
         </Reference>
     </ItemGroup>
     <ItemGroup>
@@ -38,7 +40,7 @@
         <None Remove="lib\**" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="DalamudPackager" Version="2.1.6" />
+        <PackageReference Include="DalamudPackager" Version="2.1.8" />
     </ItemGroup>
     <Target Name="PackagePlugin" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
         <DalamudPackager ProjectDir="$(ProjectDir)" OutputPath="$(OutputPath)" AssemblyName="$(AssemblyName)" MakeZip="true" />

--- a/packages.lock.json
+++ b/packages.lock.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net6.0-windows7.0": {
+      "DalamudPackager": {
+        "type": "Direct",
+        "requested": "[2.1.8, )",
+        "resolved": "2.1.8",
+        "contentHash": "YqagNXs9InxmqkXzq7kLveImxnodkBEicAhydMXVp7dFjC7xb76U6zGgAax4/BWIWfZeWzr5DJyQSev31kj81A=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
Updated to .NET 6 and DIP17 according to D17 migration guide.

The change to Hook.FromAddress was to address a deprecation warning, otherwise the plugin worked in 6.2 with no code changes required.